### PR TITLE
fix: 레이아웃 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,13 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import HomePage from "./pages/HomePage/HomePage";
 import MyPage from "./pages/MyPage/MyPage";
-import MenuBarLayout from "./Layouts/MenuBarLayout";
-import Layout from "./Layouts/Layout";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route element={<MenuBarLayout />}>
-          <Route path="/" element={<HomePage />}></Route>
-          <Route path="/mypage" element={<MyPage />}></Route>
-        </Route>
-        <Route element={<Layout />}></Route>
+        <Route path="/" element={<HomePage />}></Route>
+        <Route path="/mypage" element={<MyPage />}></Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,4 +1,3 @@
-import { Outlet } from "react-router-dom";
 import { styled } from "styled-components";
 
 const Container = styled.div`
@@ -16,12 +15,8 @@ const Container = styled.div`
   scrollbar-width: none; /* Firefox */
 `;
 
-const Layout = () => {
-  return (
-    <Container>
-      <Outlet />
-    </Container>
-  );
+const Layout = ({ children }) => {
+  return <Container>{children}</Container>;
 };
 
 export default Layout;

--- a/src/components/MenuBarLayout.jsx
+++ b/src/components/MenuBarLayout.jsx
@@ -1,6 +1,5 @@
-import { Outlet } from "react-router-dom";
 import styled from "styled-components";
-import MenuBar from "../components/MenuBar";
+import MenuBar from "./MenuBar";
 
 const Container = styled.div`
   max-width: 390px;
@@ -17,12 +16,10 @@ const Container = styled.div`
   scrollbar-width: none; /* Firefox */
 `;
 
-const MenuBarLayOut = () => {
+const MenuBarLayOut = ({ children }) => {
   return (
     <>
-      <Container>
-        <Outlet />
-      </Container>
+      <Container>{children}</Container>
       <MenuBar />
     </>
   );

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -1,13 +1,16 @@
 import { styled } from "styled-components";
 import Map from "./componenets/Map";
+import MenuBarLayout from "../../components/MenuBarLayout";
 
 const Container = styled.div``;
 
 const HomePage = () => {
   return (
-    <Container>
-      <Map />
-    </Container>
+    <MenuBarLayout>
+      <Container>
+        <Map />
+      </Container>
+    </MenuBarLayout>
   );
 };
 

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -1,12 +1,11 @@
-import styled from "styled-components";
-
-const Container = styled.div`
-  width: 100%;
-  height: 100%;
-`;
+import MenuBarLayout from "../../components/MenuBarLayout";
 
 const MyPage = () => {
-  return <Container>dasd</Container>;
+  return (
+    <MenuBarLayout>
+      <div>dasd</div>
+    </MenuBarLayout>
+  );
 };
 
 export default MyPage;


### PR DESCRIPTION
카톡에서 말한 대로 레이아웃 수정했습니다. 

앞으로 페이지를 만들 때 componenets에 있는 레이아웃 두 개를 사용하는 걸로 하는 게 좋을 거 같아요.
![image](https://github.com/Capstone-Walking/Capstone_FE/assets/77055190/cff99a5e-24ba-496c-b481-9dc35fa0223f)

그 아래에 레이아웃 folder는 나중에 따로 사용할 일이 있어서 그냥 놔둘게용.

![image](https://github.com/Capstone-Walking/Capstone_FE/assets/77055190/a6b936ff-6391-4864-9578-0e28eb4f1f58)



**정리**

**아래에 메뉴바 사용하는 페이지는 MenuBarLayout 컴포넌트 사용
메뉴바를 사용하지 않는 페이지는 그냥 Layout 사용하기 !!!!**
